### PR TITLE
KJHH-1991: react-datepicker to use same date format in each lang

### DIFF
--- a/src/main/static/src/components/common/henkilo/HenkiloViewExistingKayttooikeus.tsx
+++ b/src/main/static/src/components/common/henkilo/HenkiloViewExistingKayttooikeus.tsx
@@ -241,6 +241,7 @@ class HenkiloViewExistingKayttooikeus extends React.Component<Props, State> {
                                             ? date.isBefore(moment().add(this.props.vuosia, 'years'))
                                             : true
                                     }
+                                    dateFormat={PropertySingleton.getState().PVM_FORMAATTI}
                                 />
                             </div>
                             <div style={{ display: 'table-cell' }}>

--- a/src/main/static/src/components/common/henkilo/HenkiloViewOpenKayttooikeusanomus.tsx
+++ b/src/main/static/src/components/common/henkilo/HenkiloViewOpenKayttooikeusanomus.tsx
@@ -221,6 +221,7 @@ class HenkiloViewOpenKayttooikeusanomus extends React.Component<Props, State> {
                             haettuKayttooikeusRyhma.kayttoOikeusRyhma.id
                         )}
                         filterDate={(date) => date.isBefore(moment().add(1, 'years'))}
+                        dateFormat={PropertySingleton.getState().PVM_FORMAATTI}
                     />
                 ),
                 [headingList[8]]: this.L[haettuKayttooikeusRyhma.anomus.anomusTyyppi],

--- a/src/main/static/src/components/common/henkilo/createkayttooikeus/CKKesto.tsx
+++ b/src/main/static/src/components/common/henkilo/createkayttooikeus/CKKesto.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import DatePicker from 'react-datepicker';
 import moment from 'moment';
+import PropertySingleton from '../../../../globals/PropertySingleton';
 
 const CKKesto = ({ alkaaPvmAction, alkaaInitValue, paattyyPvmAction, paattyyInitValue, L, vuosia }) => (
     <tr key="kayttooikeusKestoField">
@@ -20,6 +21,7 @@ const CKKesto = ({ alkaaPvmAction, alkaaInitValue, paattyyPvmAction, paattyyInit
                     filterDate={(date) =>
                         Number.isInteger(vuosia) ? date.isBefore(moment().add(vuosia, 'years')) : true
                     }
+                    dateFormat={PropertySingleton.getState().PVM_FORMAATTI}
                 />
             </div>
             <div className="kayttooikeus-input-container">
@@ -33,6 +35,7 @@ const CKKesto = ({ alkaaPvmAction, alkaaInitValue, paattyyPvmAction, paattyyInit
                     filterDate={(date) =>
                         Number.isInteger(vuosia) ? date.isBefore(moment().add(vuosia, 'years')) : true
                     }
+                    dateFormat={PropertySingleton.getState().PVM_FORMAATTI}
                 />
             </div>
         </td>

--- a/src/main/static/src/components/henkilo/SimpleDatePicker.tsx
+++ b/src/main/static/src/components/henkilo/SimpleDatePicker.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import DatePicker from 'react-datepicker';
 import Moment from 'moment';
+import PropertySingleton from '../../globals/PropertySingleton';
 
 const DEFAULT_MODEL_FORMAT = 'YYYY-MM-DD';
 
@@ -30,6 +31,7 @@ class SimpleDatePicker extends React.Component<SimpleDatePickerProps> {
                 dropdownMode="select"
                 disabled={this.props.disabled}
                 filterDate={this.props.filterDate}
+                dateFormat={PropertySingleton.getState().PVM_FORMAATTI}
             />
         );
     }


### PR DESCRIPTION
* By default react-datepicker uses locale specific date format which
  is defined in rather peculiar way in moment. Add override to use
  the one defined in PropertySingleton where ever react-datepicker is
  used