### PR TITLE
KJHH-2207: Fix: Duplicate search identified information

### DIFF
--- a/src/main/static/src/components/henkilo/duplikaatit/DuplikaatitPerson.tsx
+++ b/src/main/static/src/components/henkilo/duplikaatit/DuplikaatitPerson.tsx
@@ -69,7 +69,9 @@ export default class DuplikaatitPerson extends React.Component<Props, State> {
                 <DataCell className="type">{L[this.props.header]}</DataCell>
                 <DataCell className="type">{L['DUPLIKAATIT_ONR']}</DataCell>
                 <DataCell>{henkilo.hetu}</DataCell>
-                <DataCell>{henkilo.yksiloity ? L['HENKILO_YHTEISET_KYLLA'] : L['HENKILO_YHTEISET_EI']}</DataCell>
+                <DataCell>
+                    {henkilo.yksiloity || henkilo.yksiloityVTJ ? L['HENKILO_YHTEISET_KYLLA'] : L['HENKILO_YHTEISET_EI']}
+                </DataCell>
                 <DataCell>{henkilo.kutsumanimi}</DataCell>
                 <DataCell>{henkilo.etunimet}</DataCell>
                 <DataCell>{henkilo.sukunimi}</DataCell>

--- a/src/main/static/src/types/domain/oppijanumerorekisteri/HenkiloDuplicate.ts
+++ b/src/main/static/src/types/domain/oppijanumerorekisteri/HenkiloDuplicate.ts
@@ -26,6 +26,7 @@ export type HenkiloDuplicate = {
     email: string;
     emails: string[];
     yksiloity: boolean;
+    yksiloityVTJ: boolean;
     aidinkieli: Kielisyys;
     asiointiKieli: Kielisyys;
     hakemukset: any[];


### PR DESCRIPTION
* Mark person as identified if either "yksiloity" or "yksiloityVTJ" is true.